### PR TITLE
Fix docker-compose nginx Dockerfile path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,8 +34,8 @@ services:
   nginx:
     # استفاده از Dockerfile سفارشی nginx
     build:
-      context: ./nginx 
-      dockerfile: nginx/Dockerfile
+      context: ./nginx
+      dockerfile: Dockerfile
     depends_on:
       - backend
     ports:


### PR DESCRIPTION
## Summary
- fix nginx service build path in docker-compose

## Testing
- `docker compose config` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_b_68973b94db58832fac702923433e93e8