### PR TITLE
Provide basic UI component stubs and ignore build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # Ignore node_modules directories
 node_modules/
 
+# Ignore build outputs
+build/
+frontend/build/
+
 # Ignore environment files
 .env

--- a/frontend/src/components/ui/button.js
+++ b/frontend/src/components/ui/button.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+export const Button = React.forwardRef(({ className, ...props }, ref) => (
+  <button ref={ref} className={className} {...props} />
+));
+
+Button.displayName = "Button";

--- a/frontend/src/components/ui/card.js
+++ b/frontend/src/components/ui/card.js
@@ -1,0 +1,17 @@
+import React from "react";
+
+export function Card({ className, ...props }) {
+  return <div className={className} {...props} />;
+}
+
+export function CardHeader({ className, ...props }) {
+  return <div className={className} {...props} />;
+}
+
+export function CardTitle({ className, ...props }) {
+  return <h3 className={className} {...props} />;
+}
+
+export function CardContent({ className, ...props }) {
+  return <div className={className} {...props} />;
+}

--- a/frontend/src/components/ui/checkbox.js
+++ b/frontend/src/components/ui/checkbox.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+export const Checkbox = React.forwardRef(({ className, ...props }, ref) => (
+  <input ref={ref} type="checkbox" className={className} {...props} />
+));
+
+Checkbox.displayName = "Checkbox";

--- a/frontend/src/components/ui/dialog.js
+++ b/frontend/src/components/ui/dialog.js
@@ -1,0 +1,21 @@
+import React from "react";
+
+export function Dialog({ children }) {
+  return <div>{children}</div>;
+}
+
+export function DialogTrigger({ children, ...props }) {
+  return <div {...props}>{children}</div>;
+}
+
+export function DialogContent({ className, ...props }) {
+  return <div className={className} {...props} />;
+}
+
+export function DialogHeader({ className, ...props }) {
+  return <div className={className} {...props} />;
+}
+
+export function DialogTitle({ className, ...props }) {
+  return <h3 className={className} {...props} />;
+}

--- a/frontend/src/components/ui/input.js
+++ b/frontend/src/components/ui/input.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+export const Input = React.forwardRef(({ className, ...props }, ref) => (
+  <input ref={ref} className={className} {...props} />
+));
+
+Input.displayName = "Input";

--- a/frontend/src/components/ui/label.js
+++ b/frontend/src/components/ui/label.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+export const Label = React.forwardRef(({ className, ...props }, ref) => (
+  <label ref={ref} className={className} {...props} />
+));
+
+Label.displayName = "Label";

--- a/frontend/src/components/ui/table.js
+++ b/frontend/src/components/ui/table.js
@@ -1,0 +1,25 @@
+import React from "react";
+
+export function Table({ className, ...props }) {
+  return <table className={className} {...props} />;
+}
+
+export function TableHeader({ className, ...props }) {
+  return <thead className={className} {...props} />;
+}
+
+export function TableBody({ className, ...props }) {
+  return <tbody className={className} {...props} />;
+}
+
+export function TableRow({ className, ...props }) {
+  return <tr className={className} {...props} />;
+}
+
+export function TableHead({ className, ...props }) {
+  return <th className={className} {...props} />;
+}
+
+export function TableCell({ className, ...props }) {
+  return <td className={className} {...props} />;
+}

--- a/frontend/src/components/ui/textarea.js
+++ b/frontend/src/components/ui/textarea.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+export const Textarea = React.forwardRef(({ className, ...props }, ref) => (
+  <textarea ref={ref} className={className} {...props} />
+));
+
+Textarea.displayName = "Textarea";


### PR DESCRIPTION
## Summary
- add simple React wrappers for Button, Input, Textarea, Label, Checkbox, Card, Dialog, and Table to satisfy App imports
- ignore build directories in git

## Testing
- `npm run build`
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_b_68974347e55c832f9705dd6f0d61da68