### PR TITLE
Fix Nginx return directive

### DIFF
--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -35,9 +35,11 @@ server {
     }
 
     # If the environment is production, redirect all HTTP traffic to HTTPS.
-    # The `return ... if=$redirect_to_https` directive avoids using `if` blocks
-    # and instead relies on the map defined above.
-    return 301 https://$host$request_uri if=$redirect_to_https;
+    # Use the $redirect_to_https flag from the map above to conditionally
+    # perform the redirect without relying on deprecated "return ... if" syntax.
+    if ($redirect_to_https) {
+        return 301 https://$host$request_uri;
+    }
 
     # Development proxy rules (only used when $redirect_to_https is 0)
     # Proxy API requests to the backend service on port 5000.


### PR DESCRIPTION
## Summary
- fix invalid `return ... if` syntax in Nginx template by using `if ($redirect_to_https)` block

## Testing
- `docker compose run --rm -e NGINX_ENV=production -e DOMAIN=example.com nginx nginx -t` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_b_68974c319510832f991aae3ea159bb86