### PR TITLE
Fix docker-compose service wiring

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     restart: unless-stopped
     volumes:
       - mongo_data:/data/db
+    networks: [app]
 
   backend:
     build:
@@ -29,6 +30,8 @@ services:
     environment:
       - NGINX_ENV=${NGINX_ENV:-development}
       - DOMAIN=${DOMAIN:-localhost}
+    depends_on:
+      - backend
     networks: [app]
 
   nginx:
@@ -38,6 +41,7 @@ services:
       dockerfile: Dockerfile
     depends_on:
       - backend
+      - frontend
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
## Summary
- attach mongo service to app network
- ensure frontend waits for backend
- ensure nginx waits for frontend and backend

## Testing
- `docker compose config` *(fails: command not found)*
- `docker-compose config` *(fails: command not found)*
- `npm --prefix backend test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_689750bf8ed0832f9886acf600f5d9cf