### PR TITLE
Disable HTTPS in development Nginx config

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,7 +12,7 @@ RUN npm run build
 FROM nginx:1.27-alpine AS serve
 WORKDIR /
 COPY --from=build /app/build /usr/share/nginx/html
-# فایل template و entrypoint را از ریپو کپی می‌کنیم
-COPY nginx/default.conf.template /etc/nginx/templates/default.conf.template
+# فایل‌های template و entrypoint را از ریپو کپی می‌کنیم
+COPY nginx/default.conf.template nginx/default.dev.conf.template /etc/nginx/templates/
 COPY nginx/entrypoint.sh /docker-entrypoint.d/99-envsubst.sh
 RUN chmod +x /docker-entrypoint.d/99-envsubst.sh

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -5,8 +5,8 @@ RUN apk add --no-cache gettext
 
 WORKDIR /etc/nginx
 
-# کپی قالب و اسکریپت entrypoint
-COPY default.conf.template /etc/nginx/templates/default.conf.template
+# کپی قالب‌های کانفیگ و اسکریپت entrypoint
+COPY default.conf.template default.dev.conf.template /etc/nginx/templates/
 COPY entrypoint.sh /docker-entrypoint.d/99-envsubst.sh
 
 # ایجاد دایرکتوری ACME challenge و تنظیم مالکیت

--- a/nginx/default.dev.conf.template
+++ b/nginx/default.dev.conf.template
@@ -1,0 +1,65 @@
+# ============================
+# nginx/default.dev.conf.template
+# ============================
+
+# Upgrade WebSocket connections automatically when needed.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+# Define a flag based on NGINX_ENV to control HTTPS redirection.
+# When NGINX_ENV=production, $redirect_to_https will be set to 1, otherwise 0.
+map $NGINX_ENV $redirect_to_https {
+    production 1;
+    default    0;
+}
+
+# HTTP server – handles development traffic.
+# Proxies API requests to the backend and other requests to the React dev server.
+server {
+    listen 80;
+    server_name ${DOMAIN:-localhost};
+
+    # Location used by Let's Encrypt ACME challenge
+    location ^~ /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    # Health check endpoint for Nginx.  This always returns 200 OK
+    # and is used by Docker HEALTHCHECK in the Nginx image.
+    location = /healthz {
+        return 200 'ok';
+        add_header Content-Type text/plain;
+    }
+
+    # If the environment is production, redirect all HTTP traffic to HTTPS.
+    # In development $redirect_to_https is 0, so no redirect occurs.
+    if ($redirect_to_https) {
+        return 301 https://$host$request_uri;
+    }
+
+    # Proxy API requests to the backend service on port 5000.
+    location /api/ {
+        proxy_pass http://backend:5000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+    }
+
+    # Proxy all other requests to the React dev server on port 3000.
+    location / {
+        proxy_pass http://frontend:3000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+    }
+}

--- a/nginx/entrypoint.sh
+++ b/nginx/entrypoint.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env sh
 set -eu
+# انتخاب قالب مناسب براساس متغیر محیطی NGINX_ENV
+TEMPLATE="default.conf.template"
+if [ "${NGINX_ENV:-development}" != "production" ]; then
+  TEMPLATE="default.dev.conf.template"
+fi
+
 # جایگزینی متغیرهای DOMAIN و NGINX_ENV در قالب و نوشتن نتیجه
-envsubst '${DOMAIN} ${NGINX_ENV}' < /etc/nginx/templates/default.conf.template > /etc/nginx/conf.d/default.conf
+envsubst '${DOMAIN} ${NGINX_ENV}' < /etc/nginx/templates/${TEMPLATE} > /etc/nginx/conf.d/default.conf
 exec nginx -g 'daemon off;'


### PR DESCRIPTION
## Summary
- add HTTP-only Nginx template for development
- choose config template based on `NGINX_ENV`
- ship both templates in nginx and frontend images

## Testing
- `sh -n nginx/entrypoint.sh`
- `envsubst '${DOMAIN} ${NGINX_ENV}' < nginx/default.dev.conf.template | head -n 20`
- `npm test --prefix backend` *(fails: Error: no test specified)*
- `CI=true npm test --prefix frontend` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_b_6897576af6cc832fb06ca50452ea369f