### PR TITLE
fix: correct nginx frontend upstream port

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,7 +12,3 @@ RUN npm run build
 FROM nginx:1.27-alpine AS serve
 WORKDIR /
 COPY --from=build /app/build /usr/share/nginx/html
-# فایل‌های template و entrypoint را از ریپو کپی می‌کنیم
-COPY nginx/default.conf.template nginx/default.dev.conf.template /etc/nginx/templates/
-COPY nginx/entrypoint.sh /docker-entrypoint.d/99-envsubst.sh
-RUN chmod +x /docker-entrypoint.d/99-envsubst.sh

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -17,7 +17,7 @@ map $NGINX_ENV $redirect_to_https {
 
 # HTTP server – handles both development and production.
 # In production it redirects all requests to HTTPS on port 443.  
-# In development it proxies API and frontend dev server on port 3000.
+# In development it proxies API requests and forwards to the frontend container on port 80.
 server {
     listen 80;
     server_name ${DOMAIN:-localhost};
@@ -54,9 +54,9 @@ server {
         proxy_set_header Connection $connection_upgrade;
     }
 
-    # Proxy all other requests to the React dev server on port 3000.
+    # Proxy all other requests to the frontend container (served on port 80).
     location / {
-        proxy_pass http://frontend:3000/;
+        proxy_pass http://frontend:80/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/nginx/default.dev.conf.template
+++ b/nginx/default.dev.conf.template
@@ -16,7 +16,7 @@ map $NGINX_ENV $redirect_to_https {
 }
 
 # HTTP server – handles development traffic.
-# Proxies API requests to the backend and other requests to the React dev server.
+# Proxies API requests to the backend and forwards other requests to the frontend container on port 80.
 server {
     listen 80;
     server_name ${DOMAIN:-localhost};
@@ -51,9 +51,9 @@ server {
         proxy_set_header Connection $connection_upgrade;
     }
 
-    # Proxy all other requests to the React dev server on port 3000.
+    # Proxy all other requests to the frontend container (served on port 80).
     location / {
-        proxy_pass http://frontend:3000/;
+        proxy_pass http://frontend:80/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary
- fix nginx reverse proxy to forward requests to frontend on port 80
- simplify frontend Dockerfile to serve static files without custom templates

## Testing
- `npm test` (backend) *(fails: Error: no test specified)*
- `npm test -- --watchAll=false` (frontend) *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_b_6897b14211ec832f8ab55c2c09d1e5ea