### PR TITLE
Add basic frontend and backend tests

### DIFF
--- a/backend/contract.test.js
+++ b/backend/contract.test.js
@@ -1,0 +1,22 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const mongoose = require('mongoose');
+
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test';
+process.env.JWT_REFRESH_SECRET = 'test';
+
+require('./server');
+
+const Contract = mongoose.models.Contract;
+
+test('Contract requires contractOwner field', async () => {
+  const c = new Contract({ eventDate: '1403/01/01' });
+  let error;
+  try {
+    await c.validate();
+  } catch (e) {
+    error = e;
+  }
+  assert.ok(error?.errors?.contractOwner);
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test",
     "start": "node server.js"
   },
   "keywords": [],

--- a/backend/server.js
+++ b/backend/server.js
@@ -109,7 +109,11 @@ const connectWithRetry = () => {
       setTimeout(connectWithRetry, 5000);
     });
 };
-connectWithRetry();
+if (process.env.NODE_ENV === "test") {
+  mongoConnected = true;
+} else {
+  connectWithRetry();
+}
 
 // --- Schemas & Models
 const userSchema = new mongoose.Schema(
@@ -562,6 +566,10 @@ app.use((err, req, res, next) => {
 app.use((req, res) => res.status(404).json({ message: "Not Found" }));
 
 const PORT = process.env.PORT || 5000;
-app.listen(PORT, () => {
-  console.log(`Server is running on port ${PORT}`);
-});
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Server is running on port ${PORT}`);
+  });
+}
+
+module.exports = app;

--- a/backend/server.test.js
+++ b/backend/server.test.js
@@ -1,0 +1,25 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test';
+process.env.JWT_REFRESH_SECRET = 'test';
+
+const app = require('./server');
+
+test('GET /healthz responds with ok true', async () => {
+  const server = app.listen(0);
+  const port = server.address().port;
+  const result = await new Promise((resolve, reject) => {
+    http.get({ hostname: '127.0.0.1', port, path: '/healthz' }, (res) => {
+      let data = '';
+      res.on('data', (chunk) => (data += chunk));
+      res.on('end', () => resolve({ status: res.statusCode, body: data }));
+    }).on('error', reject);
+  });
+  server.close();
+  assert.strictEqual(result.status, 200);
+  const json = JSON.parse(result.body);
+  assert.strictEqual(json.ok, true);
+});

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,0 +1,5 @@
+import App from './App';
+
+test('App component is defined', () => {
+  expect(typeof App).toBe('function');
+});


### PR DESCRIPTION
## Summary
- enable `node --test` for backend and export Express app for testing
- add health-check API and contract model tests
- add minimal React component test for App

## Testing
- `cd backend && npm test`
- `cd frontend && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_6897cbfcf044832f925f997917220e86