### PR TITLE
fix: adjust tailwind config for build

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -72,7 +72,9 @@
 
 @layer base {
   * {
-    @apply border-border;
+    /* Tailwind v4 no longer supports @apply with custom colors without @reference */
+    /* Set the default border color using the CSS variable instead */
+    border-color: hsl(var(--border));
   }
   body {
     @apply bg-background text-foreground;


### PR DESCRIPTION
## Summary
- avoid unsupported `@apply` in global styles
- set default border color via CSS variable

## Testing
- `npm run build`
- `npm test -- --watchAll=false`
- `docker build -t frontend-test .` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_b_6897cde9b850832f83ebf34be264a238