### PR TITLE
fix: ensure patch files copied before install

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,6 +5,9 @@
 FROM node:20-alpine AS build
 WORKDIR /app
 COPY frontend/package*.json ./
+# Ensure patch files are available before installation so patch-package
+# can modify dependencies like react-scripts during the postinstall step.
+COPY frontend/patches ./patches
 RUN npm ci
 COPY frontend/ ./
 RUN npm run build


### PR DESCRIPTION
## Summary
- ensure patches directory is copied before `npm ci` so patch-package applies the Tailwind PostCSS patch during Docker builds

## Testing
- `npm run build` *(fails: Cannot apply unknown utility class `bg-background`)*

------
https://chatgpt.com/codex/tasks/task_b_6897d16a2c78832f8e8037a022c86b4c