### PR TITLE
Ensure Tailwind build works with PostCSS plugin

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,7 +8,9 @@ COPY frontend/package*.json ./
 # Ensure patch files are available before installation so patch-package
 # can modify dependencies like react-scripts during the postinstall step.
 COPY frontend/patches ./patches
-RUN npm ci
+# Install all dependencies, including dev dependencies, so patch-package runs
+# and Tailwind's PostCSS plugin is available during the build.
+RUN npm ci --include=dev
 COPY frontend/ ./
 RUN npm run build
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -77,6 +77,8 @@
     border-color: hsl(var(--border));
   }
   body {
-    @apply bg-background text-foreground;
+    /* Use CSS variables directly instead of @apply to avoid unknown utility errors */
+    background-color: hsl(var(--background));
+    color: hsl(var(--foreground));
   }
 }


### PR DESCRIPTION
## Summary
- install dev dependencies during frontend image build so patch-package and Tailwind's PostCSS plugin are available
- replace @apply usage with direct CSS variables to avoid unknown `bg-background` utility errors

## Testing
- `npm run build`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_6897d40bc2a4832f8986cd4a57fc4ac0