### PR TITLE
Prevent node_modules from breaking Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+**/node_modules
+**/build


### PR DESCRIPTION
## Summary
- ignore `node_modules` and build output in Docker context to avoid clobbering dependencies during image build

## Testing
- `docker compose build --no-cache frontend` *(fails: command not found)*
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6899c322e98c832fadc21309842608fc