### PR TITLE
Improve user creation error handling and surface API failures

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -333,6 +333,9 @@ app.post(
       return res.status(201).json({ message: "User created successfully" });
     } catch (e) {
       console.error(e);
+      if (e.code === 11000) {
+        return res.status(400).json({ message: "User already exists" });
+      }
       return res.status(500).send("Server error");
     }
   }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -246,6 +246,8 @@ export default function App() {
       if (mySettingsRes.ok) {
         const mySettings = await mySettingsRes.json();
         useStore.getState().setMySettings(mySettings);
+      } else {
+        showError("خطا در دریافت تنظیمات قیمت برای خودم.");
       }
 
       const customerSettingsRes = await fetchWithAuth(
@@ -254,6 +256,8 @@ export default function App() {
       if (customerSettingsRes.ok) {
         const customerSettings = await customerSettingsRes.json();
         useStore.getState().setCustomerSettings(customerSettings);
+      } else {
+        showError("خطا در دریافت تنظیمات قیمت برای مشتری.");
       }
 
       const contractsRes = await fetchWithAuth(
@@ -262,12 +266,16 @@ export default function App() {
       if (contractsRes.ok) {
         const contractsData = await contractsRes.json();
         useStore.getState().setContracts(contractsData.contracts || []);
+      } else {
+        showError("خطا در دریافت لیست قراردادها.");
       }
 
       const usersRes = await fetchWithAuth(`${API_BASE_URL}/api/users`);
       if (usersRes.ok) {
         const usersData = await usersRes.json();
         useStore.getState().setUsers(usersData || []);
+      } else {
+        showError("خطا در دریافت کاربران.");
       }
     } catch (e) {
       console.error("Failed to fetch initial data:", e);
@@ -1911,9 +1919,11 @@ export default function App() {
         if (res.ok) {
           const data = await res.json();
           setUsers(data);
+        } else {
+          showError("خطا در دریافت کاربران.");
         }
       } catch (e) {
-        /* noop */
+        showError("خطای سرور.");
       }
     };
 
@@ -1929,7 +1939,8 @@ export default function App() {
           fetchUsers();
           setNewUser({ username: "", password: "", role: "user" });
         } else {
-          showError("خطا در ایجاد کاربر.");
+          const t = await res.json().catch(() => ({}));
+          showError(t.message || "خطا در ایجاد کاربر.");
         }
       } catch (e) {
         showError("خطای سرور.");


### PR DESCRIPTION
## Summary
- prevent duplicate username crashes when creating users
- show error messages when initial data or user list fetches fail
- display backend error message if creating a user fails

## Testing
- `npm test` (backend)
- `npm test` (frontend - fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_b_689b5fb52f00832f9a969116f9f70d44