### PR TITLE
feat: add extra items to contracts

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -212,6 +212,15 @@ const contractSchema = new mongoose.Schema(
     dinnerType: { type: String, default: "" },
     discount: { type: Number, default: 0 },
     extraDetails: { type: String, default: "" },
+    extraItems: {
+      type: [
+        {
+          title: { type: String, default: "" },
+          price: { type: Number, default: 0 },
+        },
+      ],
+      default: [],
+    },
     customerTotalCost: { type: Number, default: 0 },
     myTotalCost: { type: Number, default: 0 },
     status: {
@@ -495,6 +504,14 @@ app.post(
       dinnerType: Joi.string().allow("").default(""),
       discount: Joi.number().min(0).default(0),
       extraDetails: Joi.string().allow("").default(""),
+      extraItems: Joi.array()
+        .items(
+          Joi.object({
+            title: Joi.string().required(),
+            price: Joi.number().min(0).required(),
+          })
+        )
+        .default([]),
       customerTotalCost: Joi.number().min(0).default(0),
       myTotalCost: Joi.number().min(0).default(0),
       status: Joi.string()

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -567,6 +567,7 @@ export default function App() {
       dinnerType: "",
       discount: 0,
       extraDetails: "",
+      extraItems: [],
       customerEntryFee: "",
       customerServiceFee: "",
       customerTax: "",
@@ -677,6 +678,30 @@ export default function App() {
       setContract((prev) => ({ ...prev, [name]: parsedValue }));
     };
 
+    const addExtraItem = () => {
+      setContract((prev) => ({
+        ...prev,
+        extraItems: [...prev.extraItems, { title: "", price: 0 }],
+      }));
+    };
+
+    const handleExtraItemChange = (index, field, value) => {
+      setContract((prev) => {
+        const items = [...prev.extraItems];
+        const val = field === "price" ? Math.max(0, parseFloat(value) || 0) : value;
+        items[index] = { ...items[index], [field]: val };
+        return { ...prev, extraItems: items };
+      });
+    };
+
+    const removeExtraItem = (index) => {
+      setContract((prev) => {
+        const items = [...prev.extraItems];
+        items.splice(index, 1);
+        return { ...prev, extraItems: items };
+      });
+    };
+
     const calculateEntryFee = (start, end, rate) => {
       if (!start || !end || !start.includes(":") || !end.includes(":"))
         return rate;
@@ -731,6 +756,11 @@ export default function App() {
             next.dinnerCount * customerSettings.defaultDinnerPricePerPerson;
         else if (!next.includeDinner) next.customerDinnerPrice = 0;
 
+        const extraItemsTotal = (next.extraItems || []).reduce(
+          (sum, item) => sum + (parseFloat(item.price) || 0),
+          0
+        );
+
         const customerTotalWithoutTax =
           (next.customerEntryFee || 0) +
           (next.customerServiceFee || 0) +
@@ -740,7 +770,8 @@ export default function App() {
           (next.customerCandlePrice || 0) +
           (next.customerFlowerPrice || 0) +
           (next.customerDinnerPrice || 0) +
-          (next.customerWaterPrice || 0) -
+          (next.customerWaterPrice || 0) +
+          extraItemsTotal -
           (parseFloat(next.discount) || 0);
         next.customerTax =
           customerTotalWithoutTax * customerSettings.defaultTaxRate;
@@ -790,7 +821,8 @@ export default function App() {
           (next.myCandlePrice || 0) +
           (next.myFlowerPrice || 0) +
           (next.myDinnerPrice || 0) +
-          (next.myWaterPrice || 0) -
+          (next.myWaterPrice || 0) +
+          extraItemsTotal -
           (parseFloat(next.discount) || 0);
         next.myTax = myTotalWithoutTax * mySettings.defaultTaxRate;
         next.myTotalCost = myTotalWithoutTax + next.myTax;
@@ -807,6 +839,7 @@ export default function App() {
       contract.waterCount,
       contract.dinnerCount,
       contract.discount,
+      contract.extraItems,
       contract.includeCandle,
       contract.includeFlower,
       contract.includeJuice,
@@ -1498,6 +1531,46 @@ export default function App() {
                       rows="3"
                     />
                   </div>
+                </div>
+                <div className="mt-6">
+                  <h3 className="font-bold mb-2">آیتم‌های اضافی</h3>
+                  {contract.extraItems.map((item, idx) => (
+                    <div key={idx} className="flex items-center gap-2 mb-2">
+                      <Input
+                        placeholder="عنوان"
+                        value={item.title}
+                        onChange={(e) =>
+                          handleExtraItemChange(idx, "title", e.target.value)
+                        }
+                        className="flex-1"
+                      />
+                      <Input
+                        type="number"
+                        placeholder="قیمت"
+                        value={item.price}
+                        onChange={(e) =>
+                          handleExtraItemChange(idx, "price", e.target.value)
+                        }
+                        className="w-40"
+                        min="0"
+                      />
+                      <Button
+                        type="button"
+                        variant="destructive"
+                        onClick={() => removeExtraItem(idx)}
+                      >
+                        حذف
+                      </Button>
+                    </div>
+                  ))}
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    onClick={addExtraItem}
+                    className="mt-2"
+                  >
+                    افزودن آیتم
+                  </Button>
                 </div>
               </div>
 


### PR DESCRIPTION
## Summary
- allow storing extra contract items with title and price
- support dynamic extra items UI and total cost calculation

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_689ba5a9187c832f8e9d8346c6f499bd