### PR TITLE
Add extra hour pricing to settings and contract calculation

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -171,6 +171,7 @@ const createDefaultAdmin = async () => {
 const settingsSchema = new mongoose.Schema(
   {
     defaultHourlyRate: { type: Number, default: 0 },
+    defaultExtraHourPrice: { type: Number, default: 0 },
     defaultServiceFeePerPerson: { type: Number, default: 0 },
     defaultTaxRate: { type: Number, default: 0 },
     defaultJuicePricePerPerson: { type: Number, default: 0 },
@@ -474,6 +475,7 @@ app.post(
     }),
     [Segments.BODY]: Joi.object({
       defaultHourlyRate: Joi.number().min(0).default(0),
+      defaultExtraHourPrice: Joi.number().min(0).default(0),
       defaultServiceFeePerPerson: Joi.number().min(0).default(0),
       defaultTaxRate: Joi.number().min(0).max(100).default(0),
       defaultJuicePricePerPerson: Joi.number().min(0).default(0),

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -534,6 +534,7 @@ export default function App() {
                   <Label htmlFor={key}>
                     {{
                       defaultHourlyRate: "مبلغ ورودی ساعتی (تومان)",
+                      defaultExtraHourPrice: "قیمت هر ساعت اضافه (تومان)",
                       defaultServiceFeePerPerson:
                         "حق سرویس هر نفر خدمه (تومان)",
                       defaultTaxRate: "نرخ مالیات (٪)",
@@ -734,18 +735,18 @@ export default function App() {
       });
     };
 
-    const calculateEntryFee = (start, end, rate) => {
+    const calculateEntryFee = (start, end, baseRate, extraRate = 0) => {
       if (!start || !end || !start.includes(":") || !end.includes(":"))
-        return rate;
+        return baseRate;
       const [sh, sm] = start.split(":").map(Number);
       const [eh, em] = end.split(":").map(Number);
       const startDate = new Date(0, 0, 0, sh, sm);
       const endDate = new Date(0, 0, 0, eh, em);
       const diffInHours =
         (endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60);
-      if (diffInHours <= 2) return rate;
+      if (diffInHours <= 2) return baseRate;
       const extraHours = diffInHours - 2;
-      return rate + extraHours * (rate / 2);
+      return baseRate + extraHours * extraRate;
     };
 
     useEffect(() => {
@@ -755,7 +756,8 @@ export default function App() {
           next.customerEntryFee = calculateEntryFee(
             next.startTime,
             next.endTime,
-            customerSettings.defaultHourlyRate
+            customerSettings.defaultHourlyRate,
+            customerSettings.defaultExtraHourPrice
           );
         if (!overridden.customerServiceFee)
           next.customerServiceFee =
@@ -813,7 +815,8 @@ export default function App() {
           next.myEntryFee = calculateEntryFee(
             next.startTime,
             next.endTime,
-            mySettings.defaultHourlyRate
+            mySettings.defaultHourlyRate,
+            mySettings.defaultExtraHourPrice
           );
         if (!overridden.myServiceFee)
           next.myServiceFee =


### PR DESCRIPTION
## Summary
- add `defaultExtraHourPrice` to settings schema and API validation
- display "price per extra hour" field in settings UI
- calculate contract entry fee using the extra hour price for durations beyond two hours

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_689caa0eac9c832fad6c674d589203c0