### PR TITLE
feat: add studio contract form and backend

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -244,6 +244,45 @@ const contractSchema = new mongoose.Schema(
 
 const Contract = mongoose.model("Contract", contractSchema);
 
+const studioContractSchema = new mongoose.Schema(
+  {
+    fullName: { type: String, required: true, index: true },
+    ceremonyType: { type: String, default: "" },
+    invoiceDate: { type: String, default: "" },
+    lunch: { type: String, default: "" },
+    dinner: { type: String, default: "" },
+    homeAddress: { type: String, default: "" },
+    groomName: { type: String, default: "" },
+    groomPhone: { type: String, default: "" },
+    brideName: { type: String, default: "" },
+    bridePhone: { type: String, default: "" },
+    ceremonyLocation: { type: String, default: "" },
+    clipProduction: { type: Boolean, default: false },
+    insideProvince: { type: Boolean, default: false },
+    outsideProvince: { type: Boolean, default: false },
+    notes: { type: String, default: "" },
+    hennaDate: { type: String, default: "" },
+    engagementDate: { type: String, default: "" },
+    weddingDate: { type: String, default: "" },
+    services: {
+      type: [
+        {
+          name: String,
+          quantity: String,
+          price: String,
+          details: String,
+        },
+      ],
+      default: [],
+    },
+    totalPrice: { type: String, default: "" },
+    prePayment: { type: String, default: "" },
+  },
+  { timestamps: true }
+);
+
+const StudioContract = mongoose.model("StudioContract", studioContractSchema);
+
 const contractBodySchema = Joi.object({
   contractOwner: Joi.string().required(),
   groomFirstName: Joi.string().required(),
@@ -288,6 +327,39 @@ const contractBodySchema = Joi.object({
   includeFirework: Joi.boolean().default(false),
   includeWater: Joi.boolean().default(false),
   includeDinner: Joi.boolean().default(false),
+}).unknown(false);
+
+const studioContractBodySchema = Joi.object({
+  fullName: Joi.string().required(),
+  ceremonyType: Joi.string().allow("").default(""),
+  invoiceDate: Joi.string().allow("").default(""),
+  lunch: Joi.string().allow("").default(""),
+  dinner: Joi.string().allow("").default(""),
+  homeAddress: Joi.string().allow("").default(""),
+  groomName: Joi.string().allow("").default(""),
+  groomPhone: Joi.string().allow("").default(""),
+  brideName: Joi.string().allow("").default(""),
+  bridePhone: Joi.string().allow("").default(""),
+  ceremonyLocation: Joi.string().allow("").default(""),
+  clipProduction: Joi.boolean().default(false),
+  insideProvince: Joi.boolean().default(false),
+  outsideProvince: Joi.boolean().default(false),
+  notes: Joi.string().allow("").default(""),
+  hennaDate: Joi.string().allow("").default(""),
+  engagementDate: Joi.string().allow("").default(""),
+  weddingDate: Joi.string().allow("").default(""),
+  services: Joi.array()
+    .items(
+      Joi.object({
+        name: Joi.string().required(),
+        quantity: Joi.string().allow("").default(""),
+        price: Joi.string().allow("").default(""),
+        details: Joi.string().allow("").default(""),
+      })
+    )
+    .default([]),
+  totalPrice: Joi.string().allow("").default(""),
+  prePayment: Joi.string().allow("").default(""),
 }).unknown(false);
 
 // --- Sample data seeding
@@ -817,6 +889,32 @@ app.post(
     }
   }
 );
+
+// Studio Contracts
+app.post(
+  "/api/studio-contracts",
+  authMiddleware,
+  celebrate({ [Segments.BODY]: studioContractBodySchema }),
+  async (req, res) => {
+    try {
+      const doc = await StudioContract.create(req.body);
+      return res.status(201).json(doc);
+    } catch (e) {
+      console.error(e);
+      return res.status(500).send("Server error");
+    }
+  }
+);
+
+app.get("/api/studio-contracts", authMiddleware, async (req, res) => {
+  try {
+    const docs = await StudioContract.find({}).sort({ createdAt: -1 });
+    return res.json(docs);
+  } catch (e) {
+    console.error(e);
+    return res.status(500).send("Server error");
+  }
+});
 
 // Contracts
 app.post(

--- a/backend/studioContract.test.js
+++ b/backend/studioContract.test.js
@@ -1,0 +1,22 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const mongoose = require('mongoose');
+
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test';
+process.env.JWT_REFRESH_SECRET = 'test';
+
+require('./server');
+
+const StudioContract = mongoose.models.StudioContract;
+
+test('StudioContract requires fullName field', async () => {
+  const c = new StudioContract({});
+  let error;
+  try {
+    await c.validate();
+  } catch (e) {
+    error = e;
+  }
+  assert.ok(error?.errors?.fullName);
+});

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2607,7 +2607,13 @@ export default function App() {
       case "createContract":
         return <CreateContract />;
       case "studioContract":
-        return <StudioContract />;
+        return (
+          <StudioContract
+            BackButton={BackButton}
+            navigate={navigate}
+            showError={showError}
+          />
+        );
       case "contractsList":
         return <ContractsList />;
       case "reporting":

--- a/frontend/src/StudioContract.jsx
+++ b/frontend/src/StudioContract.jsx
@@ -12,6 +12,9 @@ import {
   TableBody,
   TableCell,
 } from "@/components/ui/table";
+import DatePicker from "react-multi-date-picker";
+import persian from "react-date-object/calendars/persian";
+import persian_fa from "react-date-object/locales/persian_fa";
 
 const serviceNames = [
   "دوربین فیلمبرداری",
@@ -28,7 +31,25 @@ const serviceNames = [
   "ویدئو پروژکتور",
 ];
 
-const StudioContract = () => {
+const inputClass =
+  "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive";
+
+const API_BASE_URL = window.location.origin;
+
+const toEnglishDigits = (str = "") =>
+  str.replace(/[۰-۹]/g, (d) => "0123456789"["۰۱۲۳۴۵۶۷۸۹".indexOf(d)]);
+
+const fetchWithAuth = async (url, options = {}) => {
+  const token = localStorage.getItem("token");
+  const headers = {
+    "Content-Type": "application/json",
+    ...(token && { Authorization: `Bearer ${token}` }),
+    ...options.headers,
+  };
+  return fetch(url, { ...options, headers });
+};
+
+const StudioContract = ({ BackButton, navigate, showError }) => {
   const [formData, setFormData] = useState({
     fullName: "",
     ceremonyType: "",
@@ -75,187 +96,273 @@ const StudioContract = () => {
     });
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    // Placeholder submit handler
-    alert("قرارداد با موفقیت ثبت شد");
+    try {
+      const res = await fetchWithAuth(`${API_BASE_URL}/api/studio-contracts`, {
+        method: "POST",
+        body: JSON.stringify(formData),
+      });
+      if (res.ok) {
+        alert("قرارداد با موفقیت ثبت شد");
+        navigate("contractsList");
+      } else {
+        const t = await res.text();
+        if (showError) showError(t || "خطا در ثبت قرارداد.");
+        else alert(t || "خطا در ثبت قرارداد.");
+      }
+    } catch (e) {
+      if (showError) showError("خطای سرور.");
+      else alert("خطای سرور.");
+    }
   };
 
   return (
-    <div className="p-4 max-w-4xl mx-auto">
-      <h1 className="text-2xl font-bold mb-4">ثبت قرارداد استدیو جم</h1>
-      <form onSubmit={handleSubmit} className="space-y-6">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div>
-            <Label htmlFor="fullName">نام و نام خانوادگی</Label>
-            <Input
-              id="fullName"
-              name="fullName"
-              value={formData.fullName}
-              onChange={handleInputChange}
-            />
+    <div className="container mx-auto p-8 min-h-screen font-iransans">
+      {BackButton && <BackButton />}
+      <h1 className="text-4xl font-extrabold mb-8 text-center text-gray-800">
+        ثبت قرارداد استدیو جم
+      </h1>
+      <form onSubmit={handleSubmit} className="space-y-8">
+        <div>
+          <h2 className="text-xl font-bold mb-4 border-b pb-2">
+            اطلاعات کلی قرارداد
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <Label htmlFor="fullName">نام و نام خانوادگی</Label>
+              <Input
+                id="fullName"
+                name="fullName"
+                value={formData.fullName}
+                onChange={handleInputChange}
+                required
+              />
+            </div>
+            <div>
+              <Label htmlFor="ceremonyType">نوع مراسم</Label>
+              <Input
+                id="ceremonyType"
+                name="ceremonyType"
+                value={formData.ceremonyType}
+                onChange={handleInputChange}
+              />
+            </div>
+            <div>
+              <Label htmlFor="lunch">ناهار</Label>
+              <Input
+                id="lunch"
+                name="lunch"
+                value={formData.lunch}
+                onChange={handleInputChange}
+              />
+            </div>
+            <div>
+              <Label htmlFor="dinner">شام</Label>
+              <Input
+                id="dinner"
+                name="dinner"
+                value={formData.dinner}
+                onChange={handleInputChange}
+              />
+            </div>
+            <div className="md:col-span-2">
+              <Label htmlFor="homeAddress">آدرس محل سکونت</Label>
+              <Textarea
+                id="homeAddress"
+                name="homeAddress"
+                value={formData.homeAddress}
+                onChange={handleInputChange}
+                rows={2}
+              />
+            </div>
+            <div>
+              <Label htmlFor="groomName">نام داماد</Label>
+              <Input
+                id="groomName"
+                name="groomName"
+                value={formData.groomName}
+                onChange={handleInputChange}
+              />
+            </div>
+            <div>
+              <Label htmlFor="groomPhone">تلفن داماد (همراه/ثابت)</Label>
+              <Input
+                id="groomPhone"
+                name="groomPhone"
+                value={formData.groomPhone}
+                onChange={handleInputChange}
+              />
+            </div>
+            <div>
+              <Label htmlFor="brideName">نام عروس</Label>
+              <Input
+                id="brideName"
+                name="brideName"
+                value={formData.brideName}
+                onChange={handleInputChange}
+              />
+            </div>
+            <div>
+              <Label htmlFor="bridePhone">تلفن عروس (همراه/ثابت)</Label>
+              <Input
+                id="bridePhone"
+                name="bridePhone"
+                value={formData.bridePhone}
+                onChange={handleInputChange}
+              />
+            </div>
+            <div className="md:col-span-2">
+              <Label htmlFor="ceremonyLocation">محل مراسم</Label>
+              <Input
+                id="ceremonyLocation"
+                name="ceremonyLocation"
+                value={formData.ceremonyLocation}
+                onChange={handleInputChange}
+              />
+            </div>
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="clipProduction"
+                checked={formData.clipProduction}
+                onCheckedChange={(checked) =>
+                  handleCheckboxChange("clipProduction", checked)
+                }
+              />
+              <Label htmlFor="clipProduction">ساخت کلیپ</Label>
+            </div>
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="insideProvince"
+                checked={formData.insideProvince}
+                onCheckedChange={(checked) =>
+                  handleCheckboxChange("insideProvince", checked)
+                }
+              />
+              <Label htmlFor="insideProvince">داخل استان</Label>
+            </div>
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="outsideProvince"
+                checked={formData.outsideProvince}
+                onCheckedChange={(checked) =>
+                  handleCheckboxChange("outsideProvince", checked)
+                }
+              />
+              <Label htmlFor="outsideProvince">خارج استان</Label>
+            </div>
+            <div className="md:col-span-2">
+              <Label htmlFor="notes">توضیحات</Label>
+              <Textarea
+                id="notes"
+                name="notes"
+                value={formData.notes}
+                onChange={handleInputChange}
+                rows={3}
+              />
+            </div>
           </div>
-          <div>
-            <Label htmlFor="ceremonyType">نوع مراسم</Label>
-            <Input
-              id="ceremonyType"
-              name="ceremonyType"
-              value={formData.ceremonyType}
-              onChange={handleInputChange}
-            />
-          </div>
-          <div>
-            <Label htmlFor="invoiceDate">مورخه رسید فاکتور</Label>
-            <Input
-              id="invoiceDate"
-              name="invoiceDate"
-              value={formData.invoiceDate}
-              onChange={handleInputChange}
-              placeholder="مثلاً 1402/01/01"
-            />
-          </div>
-          <div>
-            <Label htmlFor="lunch">ناهار</Label>
-            <Input
-              id="lunch"
-              name="lunch"
-              value={formData.lunch}
-              onChange={handleInputChange}
-            />
-          </div>
-          <div>
-            <Label htmlFor="dinner">شام</Label>
-            <Input
-              id="dinner"
-              name="dinner"
-              value={formData.dinner}
-              onChange={handleInputChange}
-            />
-          </div>
-          <div className="md:col-span-2">
-            <Label htmlFor="homeAddress">آدرس محل سکونت</Label>
-            <Textarea
-              id="homeAddress"
-              name="homeAddress"
-              value={formData.homeAddress}
-              onChange={handleInputChange}
-              rows={2}
-            />
-          </div>
-          <div>
-            <Label htmlFor="groomName">نام داماد</Label>
-            <Input
-              id="groomName"
-              name="groomName"
-              value={formData.groomName}
-              onChange={handleInputChange}
-            />
-          </div>
-          <div>
-            <Label htmlFor="groomPhone">تلفن داماد (همراه/ثابت)</Label>
-            <Input
-              id="groomPhone"
-              name="groomPhone"
-              value={formData.groomPhone}
-              onChange={handleInputChange}
-            />
-          </div>
-          <div>
-            <Label htmlFor="brideName">نام عروس</Label>
-            <Input
-              id="brideName"
-              name="brideName"
-              value={formData.brideName}
-              onChange={handleInputChange}
-            />
-          </div>
-          <div>
-            <Label htmlFor="bridePhone">تلفن عروس (همراه/ثابت)</Label>
-            <Input
-              id="bridePhone"
-              name="bridePhone"
-              value={formData.bridePhone}
-              onChange={handleInputChange}
-            />
-          </div>
-          <div className="md:col-span-2">
-            <Label htmlFor="ceremonyLocation">محل مراسم</Label>
-            <Input
-              id="ceremonyLocation"
-              name="ceremonyLocation"
-              value={formData.ceremonyLocation}
-              onChange={handleInputChange}
-            />
-          </div>
-          <div className="flex items-center space-x-2">
-            <Checkbox
-              id="clipProduction"
-              checked={formData.clipProduction}
-              onCheckedChange={(checked) =>
-                handleCheckboxChange("clipProduction", checked)
-              }
-            />
-            <Label htmlFor="clipProduction">ساخت کلیپ</Label>
-          </div>
-          <div className="flex items-center space-x-2">
-            <Checkbox
-              id="insideProvince"
-              checked={formData.insideProvince}
-              onCheckedChange={(checked) =>
-                handleCheckboxChange("insideProvince", checked)
-              }
-            />
-            <Label htmlFor="insideProvince">داخل استان</Label>
-          </div>
-          <div className="flex items-center space-x-2">
-            <Checkbox
-              id="outsideProvince"
-              checked={formData.outsideProvince}
-              onCheckedChange={(checked) =>
-                handleCheckboxChange("outsideProvince", checked)
-              }
-            />
-            <Label htmlFor="outsideProvince">خارج استان</Label>
-          </div>
-          <div className="md:col-span-2">
-            <Label htmlFor="notes">توضیحات</Label>
-            <Textarea
-              id="notes"
-              name="notes"
-              value={formData.notes}
-              onChange={handleInputChange}
-              rows={3}
-            />
-          </div>
-          <div>
-            <Label htmlFor="hennaDate">مورخه حنابندان</Label>
-            <Input
-              id="hennaDate"
-              name="hennaDate"
-              value={formData.hennaDate}
-              onChange={handleInputChange}
-              placeholder="مثلاً 1402/01/01"
-            />
-          </div>
-          <div>
-            <Label htmlFor="engagementDate">مورخه عقد</Label>
-            <Input
-              id="engagementDate"
-              name="engagementDate"
-              value={formData.engagementDate}
-              onChange={handleInputChange}
-              placeholder="مثلاً 1402/01/01"
-            />
-          </div>
-          <div>
-            <Label htmlFor="weddingDate">مورخه عروسی</Label>
-            <Input
-              id="weddingDate"
-              name="weddingDate"
-              value={formData.weddingDate}
-              onChange={handleInputChange}
-              placeholder="مثلاً 1402/01/01"
-            />
+        </div>
+
+        <div>
+          <h2 className="text-xl font-bold mb-4 border-b pb-2">تاریخ‌ها</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <Label htmlFor="invoiceDate">مورخه رسید فاکتور</Label>
+              <DatePicker
+                calendar={persian}
+                locale={persian_fa}
+                value={formData.invoiceDate}
+                onChange={(value) =>
+                  handleInputChange({
+                    target: {
+                      name: "invoiceDate",
+                      value: toEnglishDigits(value?.format("YYYY/MM/DD") || ""),
+                    },
+                  })
+                }
+                format="YYYY/MM/DD"
+                containerClassName="w-full"
+                inputClass={inputClass}
+                inputProps={{
+                  id: "invoiceDate",
+                  name: "invoiceDate",
+                  placeholder: "مثال: ۱۴۰۲/۰۱/۰۱",
+                }}
+              />
+            </div>
+            <div>
+              <Label htmlFor="hennaDate">مورخه حنابندان</Label>
+              <DatePicker
+                calendar={persian}
+                locale={persian_fa}
+                value={formData.hennaDate}
+                onChange={(value) =>
+                  handleInputChange({
+                    target: {
+                      name: "hennaDate",
+                      value: toEnglishDigits(value?.format("YYYY/MM/DD") || ""),
+                    },
+                  })
+                }
+                format="YYYY/MM/DD"
+                containerClassName="w-full"
+                inputClass={inputClass}
+                inputProps={{
+                  id: "hennaDate",
+                  name: "hennaDate",
+                  placeholder: "مثال: ۱۴۰۲/۰۱/۰۱",
+                }}
+              />
+            </div>
+            <div>
+              <Label htmlFor="engagementDate">مورخه عقد</Label>
+              <DatePicker
+                calendar={persian}
+                locale={persian_fa}
+                value={formData.engagementDate}
+                onChange={(value) =>
+                  handleInputChange({
+                    target: {
+                      name: "engagementDate",
+                      value: toEnglishDigits(value?.format("YYYY/MM/DD") || ""),
+                    },
+                  })
+                }
+                format="YYYY/MM/DD"
+                containerClassName="w-full"
+                inputClass={inputClass}
+                inputProps={{
+                  id: "engagementDate",
+                  name: "engagementDate",
+                  placeholder: "مثال: ۱۴۰۲/۰۱/۰۱",
+                }}
+              />
+            </div>
+            <div>
+              <Label htmlFor="weddingDate">مورخه عروسی</Label>
+              <DatePicker
+                calendar={persian}
+                locale={persian_fa}
+                value={formData.weddingDate}
+                onChange={(value) =>
+                  handleInputChange({
+                    target: {
+                      name: "weddingDate",
+                      value: toEnglishDigits(value?.format("YYYY/MM/DD") || ""),
+                    },
+                  })
+                }
+                format="YYYY/MM/DD"
+                containerClassName="w-full"
+                inputClass={inputClass}
+                inputProps={{
+                  id: "weddingDate",
+                  name: "weddingDate",
+                  placeholder: "مثال: ۱۴۰۲/۰۱/۰۱",
+                }}
+              />
+            </div>
           </div>
         </div>
 
@@ -304,24 +411,27 @@ const StudioContract = () => {
           </Table>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div>
-            <Label htmlFor="totalPrice">قیمت کل</Label>
-            <Input
-              id="totalPrice"
-              name="totalPrice"
-              value={formData.totalPrice}
-              onChange={handleInputChange}
-            />
-          </div>
-          <div>
-            <Label htmlFor="prePayment">پیش پرداخت</Label>
-            <Input
-              id="prePayment"
-              name="prePayment"
-              value={formData.prePayment}
-              onChange={handleInputChange}
-            />
+        <div>
+          <h2 className="text-xl font-bold mb-4 border-b pb-2">مبالغ</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <Label htmlFor="totalPrice">قیمت کل</Label>
+              <Input
+                id="totalPrice"
+                name="totalPrice"
+                value={formData.totalPrice}
+                onChange={handleInputChange}
+              />
+            </div>
+            <div>
+              <Label htmlFor="prePayment">پیش پرداخت</Label>
+              <Input
+                id="prePayment"
+                name="prePayment"
+                value={formData.prePayment}
+                onChange={handleInputChange}
+              />
+            </div>
           </div>
         </div>
 
@@ -334,4 +444,3 @@ const StudioContract = () => {
 };
 
 export default StudioContract;
-


### PR DESCRIPTION
## Summary
- build Studio Contract page with back button, Persian date pickers, and grouped fields
- create MongoDB schema and API routes to store studio contracts
- add validation test for StudioContract model

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_b_689cd8d067d8832f839f510caa7c34dc