### PR TITLE
Fix contract edit page data loading

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1867,6 +1867,18 @@ export default function App() {
       }
     };
 
+    const handleEdit = async (id) => {
+      const res = await fetchWithAuth(`${API_BASE_URL}/api/contracts/${id}`);
+      if (res.ok) {
+        const data = await res.json();
+        setEditingContract(normalizeContractTimes([data])[0]);
+        navigate("createContract");
+      } else {
+        const t = await res.text();
+        showError(t || "خطا در دریافت اطلاعات قرارداد.");
+      }
+    };
+
     const filteredContracts = contracts.filter((c) => {
       const termMatch = searchTerm
         ? (c.contractOwner || "")
@@ -2416,10 +2428,7 @@ export default function App() {
                           <Button
                             variant="outline"
                             size="sm"
-                            onClick={() => {
-                              setEditingContract(c);
-                              navigate("createContract");
-                            }}
+                            onClick={() => handleEdit(c._id)}
                           >
                             <Pencil className="h-4 w-4 ml-2" /> ویرایش
                           </Button>


### PR DESCRIPTION
## Summary
- fetch full contract details on edit so information loads on the edit page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689ce30961dc832fb05d16b9dc65a482