### PR TITLE
Add dedicated dashboard navigation page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,7 +9,7 @@ import StaggeredGrid from "@/components/StaggeredGrid";
 import StudioContract from "./StudioContract";
 import HallContracts from "./HallContracts";
 import StudioContracts from "./StudioContracts";
-import ContractsList from "./ContractsList";
+import Dashboard from "./Dashboard";
 
 import {
   useStore,
@@ -1799,12 +1799,10 @@ export default function App() {
         return <StudioContracts BackButton={BackButton} />;
       case "dashboard":
         return (
-          <ContractsList
-            BackButton={BackButton}
+          <Dashboard
             fetchAllData={fetchAllData}
             handleLogout={handleLogout}
             navigate={navigate}
-            showError={showError}
           />
         );
       case "reporting":
@@ -1819,12 +1817,10 @@ export default function App() {
         );
       default:
         return (
-          <ContractsList
-            BackButton={BackButton}
+          <Dashboard
             fetchAllData={fetchAllData}
             handleLogout={handleLogout}
             navigate={navigate}
-            showError={showError}
           />
         );
     }

--- a/frontend/src/ContractsList.jsx
+++ b/frontend/src/ContractsList.jsx
@@ -26,15 +26,9 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import {
-  Settings,
-  User,
-  Plus,
-  FileText,
   ChevronLeft,
   ChevronRight,
   Eye,
-  BarChart,
-  Users,
   Search,
   Pencil,
   Trash,
@@ -50,13 +44,11 @@ const ContractsList = ({
   title = "داشبورد",
 }) => {
   const contracts = useStore((state) => state.contracts);
-  const allowedPages = useStore((state) => state.allowedPages);
   const role = useStore((state) => state.role);
   const removeContract = useStore((state) => state.removeContract);
   const updateContract = useStore((state) => state.updateContract);
   const setEditingContract = useStore((state) => state.setEditingContract);
   const isAdmin = role === "admin";
-  const isDashboard = title === "داشبورد";
   const [searchTerm, setSearchTerm] = useState("");
   const [currentPageNumber, setCurrentPageNumber] = useState(1);
   const contractsPerPage = 5;
@@ -284,72 +276,6 @@ const ContractsList = ({
                   </form>
                 </DialogContent>
               </Dialog>
-              {allowedPages.includes("mySettings") && (
-                <Button
-                  onClick={() => navigate("mySettings")}
-                  variant="secondary"
-                >
-                  <Settings className="h-4 w-4 mr-2" /> تنظیمات قیمت برای خودم
-                </Button>
-              )}
-              {allowedPages.includes("customerSettings") && (
-                <Button
-                  onClick={() => navigate("customerSettings")}
-                  variant="secondary"
-                >
-                  <User className="h-4 w-4 mr-2" /> تنظیمات قیمت برای مشتری
-                </Button>
-              )}
-              {allowedPages.includes("reporting") && (
-                <Button
-                  onClick={() => navigate("reporting")}
-                  variant="secondary"
-                >
-                  <BarChart className="h-4 w-4 mr-2" /> گزارش‌گیری
-                </Button>
-              )}
-              {allowedPages.includes("userManagement") && (
-                <Button
-                  onClick={() => navigate("userManagement")}
-                  variant="secondary"
-                >
-                  <Users className="h-4 w-4 mr-2" /> مدیریت کاربران
-                </Button>
-              )}
-              {allowedPages.includes("createContract") && (
-                <Button
-                  onClick={() => {
-                    setEditingContract(null);
-                    navigate("createContract");
-                  }}
-                >
-                  <Plus className="h-4 w-4 mr-2" /> ثبت قرارداد سالن عقد
-                </Button>
-              )}
-              {allowedPages.includes("studioContract") && (
-                <Button
-                  onClick={() => navigate("studioContract")}
-                  variant="secondary"
-                >
-                  <FileText className="h-4 w-4 mr-2" /> قرارداد استدیو جم
-                </Button>
-              )}
-              {isDashboard && allowedPages.includes("hallContracts") && (
-                <Button
-                  onClick={() => navigate("hallContracts")}
-                  variant="secondary"
-                >
-                  <FileText className="h-4 w-4 mr-2" /> قرارداد های سالن عقد
-                </Button>
-              )}
-              {isDashboard && allowedPages.includes("studioContracts") && (
-                <Button
-                  onClick={() => navigate("studioContracts")}
-                  variant="secondary"
-                >
-                  <FileText className="h-4 w-4 mr-2" /> قرارداد های استدیو جم
-                </Button>
-              )}
             </div>
           </div>
           <div className="overflow-x-auto">

--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { useStore } from "./store";
+import { Button } from "@/components/ui/button";
+import {
+  RefreshCcw,
+  Settings,
+  User,
+  BarChart,
+  Users,
+  Plus,
+  FileText,
+} from "lucide-react";
+
+const Dashboard = ({ fetchAllData, handleLogout, navigate }) => {
+  const allowedPages = useStore((state) => state.allowedPages);
+
+  return (
+    <div className="container mx-auto p-8 min-h-screen font-iransans">
+      <div className="flex justify-between items-center mb-8">
+        <h1 className="text-4xl font-extrabold text-gray-800">داشبورد</h1>
+        <div className="flex gap-2">
+          <Button onClick={fetchAllData} variant="outline">
+            <RefreshCcw className="h-4 w-4 mr-2" />
+            به‌روزرسانی
+          </Button>
+          <Button onClick={handleLogout} variant="destructive">
+            خروج
+          </Button>
+        </div>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+        {allowedPages.includes("mySettings") && (
+          <Button onClick={() => navigate("mySettings")} variant="secondary">
+            <Settings className="h-4 w-4 mr-2" /> تنظیمات قیمت برای خودم
+          </Button>
+        )}
+        {allowedPages.includes("customerSettings") && (
+          <Button
+            onClick={() => navigate("customerSettings")}
+            variant="secondary"
+          >
+            <User className="h-4 w-4 mr-2" /> تنظیمات قیمت برای مشتری
+          </Button>
+        )}
+        {allowedPages.includes("reporting") && (
+          <Button onClick={() => navigate("reporting")} variant="secondary">
+            <BarChart className="h-4 w-4 mr-2" /> گزارش‌گیری
+          </Button>
+        )}
+        {allowedPages.includes("userManagement") && (
+          <Button
+            onClick={() => navigate("userManagement")}
+            variant="secondary"
+          >
+            <Users className="h-4 w-4 mr-2" /> مدیریت کاربران
+          </Button>
+        )}
+        {allowedPages.includes("createContract") && (
+          <Button
+            onClick={() => {
+              navigate("createContract");
+            }}
+          >
+            <Plus className="h-4 w-4 mr-2" /> ثبت قرارداد سالن عقد
+          </Button>
+        )}
+        {allowedPages.includes("studioContract") && (
+          <Button onClick={() => navigate("studioContract")} variant="secondary">
+            <FileText className="h-4 w-4 mr-2" /> قرارداد استدیو جم
+          </Button>
+        )}
+        {allowedPages.includes("hallContracts") && (
+          <Button onClick={() => navigate("hallContracts")} variant="secondary">
+            <FileText className="h-4 w-4 mr-2" /> لیست قرارداد های سالن عقد
+          </Button>
+        )}
+        {allowedPages.includes("studioContracts") && (
+          <Button
+            onClick={() => navigate("studioContracts")}
+            variant="secondary"
+          >
+            <FileText className="h-4 w-4 mr-2" /> لیست قرارداد های استدیو جم
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Dashboard;


### PR DESCRIPTION
## Summary
- add dashboard component with navigation buttons for settings, reporting, contracts, and lists
- route dashboard requests through new component instead of contract list

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689d05adbe00832faccfca4ebbe72e2a