### PR TITLE
feat: separate contracts list page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,6 +10,7 @@ import StudioContract from "./StudioContract";
 import HallContracts from "./HallContracts";
 import StudioContracts from "./StudioContracts";
 import Dashboard from "./Dashboard";
+import ContractsList from "./ContractsList";
 
 import {
   useStore,
@@ -74,6 +75,7 @@ const PAGE_OPTIONS = [
   { key: "userManagement", label: "مدیریت کاربران" },
   { key: "createContract", label: "ثبت قرارداد سالن عقد" },
   { key: "studioContract", label: "ثبت قرارداد استدیو جم" },
+  { key: "contractsList", label: "لیست قرارداد ها" },
   { key: "hallContracts", label: "قراردادهای سالن عقد" },
   { key: "studioContracts", label: "قراردادهای استدیو جم" },
 ];
@@ -1797,6 +1799,17 @@ export default function App() {
         );
       case "studioContracts":
         return <StudioContracts BackButton={BackButton} />;
+      case "contractsList":
+        return (
+          <ContractsList
+            BackButton={BackButton}
+            fetchAllData={fetchAllData}
+            handleLogout={handleLogout}
+            navigate={navigate}
+            showError={showError}
+            title="لیست قرارداد ها"
+          />
+        );
       case "dashboard":
         return (
           <Dashboard

--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -69,6 +69,11 @@ const Dashboard = ({ fetchAllData, handleLogout, navigate }) => {
             <FileText className="h-4 w-4 mr-2" /> قرارداد استدیو جم
           </Button>
         )}
+        {allowedPages.includes("contractsList") && (
+          <Button onClick={() => navigate("contractsList")} variant="secondary">
+            <FileText className="h-4 w-4 mr-2" /> لیست قرارداد ها
+          </Button>
+        )}
         {allowedPages.includes("hallContracts") && (
           <Button onClick={() => navigate("hallContracts")} variant="secondary">
             <FileText className="h-4 w-4 mr-2" /> لیست قرارداد های سالن عقد


### PR DESCRIPTION
## Summary
- add contracts list entry to page options and router
- navigate to new contracts list page from dashboard

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689d0832a430832fa2d63bc31465a972