### PR TITLE
fix: include missing contract pages in admin permissions

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -131,6 +131,13 @@ const PAGE_NAMES = [
   "userManagement",
   "createContract",
   "studioContract",
+  // Pages related to contract listings were missing here which caused
+  // selected permissions for these sections to be discarded on save.
+  // Including them ensures allowedPages for admin users cover every
+  // page exposed on the frontend.
+  "contractsList",
+  "hallContracts",
+  "studioContracts",
 ];
 
 const userSchema = new mongoose.Schema(


### PR DESCRIPTION
## Summary
- include contract list and studio/hall contract pages in backend `PAGE_NAMES`

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_b_689d0d7ae0a8832faeecfb24bfceeab2