### PR TITLE
Fix user access dialog updates

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1945,7 +1945,21 @@ function UserManagement({ showError, navigate, BackButton }) {
       });
       if (res.ok) {
         alert("دسترسی‌ها به‌روزرسانی شد.");
-        fetchUsers();
+        // Optimistically update UI
+        setUsers((users) =>
+          users.map((u) =>
+            u._id === id
+              ? {
+                  ...u,
+                  allowedPages: isAdmin
+                    ? PAGE_OPTIONS.map((p) => p.key)
+                    : pages,
+                  role: isAdmin ? "admin" : "user",
+                }
+              : u
+          )
+        );
+        await fetchUsers();
         return true;
       } else {
         showError("خطا در به‌روزرسانی دسترسی‌ها.");


### PR DESCRIPTION
## Summary
- Optimistically update user role and allowed pages when saving the access dialog
- Refresh user list after saving permissions

## Testing
- `npm test --prefix backend`
- `npm run build --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_b_689d0fcddff4832fb253c299a21a06a2