### PR TITLE
fix: allow functional updates in user store

### DIFF
--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -82,7 +82,10 @@ export const useStore = create((set) => ({
   updateMySettings: (settings) => set({ mySettings: settings }),
   updateCustomerSettings: (settings) => set({ customerSettings: settings }),
 
-  setUsers: (users) => set({ users }),
+  setUsers: (users) =>
+    set((state) => ({
+      users: typeof users === "function" ? users(state.users) : users,
+    })),
   setAllowedPages: (allowedPages) => {
     localStorage.setItem("allowedPages", JSON.stringify(allowedPages));
     set({ allowedPages });


### PR DESCRIPTION
## Summary
- support functional updates in setUsers to avoid storing functions and causing `users.map` errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689d145df0bc832f8a252d42d71219fa