### PR TITLE
fix: persist permission removals

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -819,9 +819,9 @@ app.put(
         user.allowedPages = PAGE_NAMES;
       } else if (role === "user" && user.role === "admin") {
         user.role = "user";
-        if (allowedPages) user.allowedPages = allowedPages;
+        if (allowedPages !== undefined) user.allowedPages = allowedPages;
       } else {
-        if (allowedPages) user.allowedPages = allowedPages;
+        if (allowedPages !== undefined) user.allowedPages = allowedPages;
       }
       // ensure admin always has all pages including userManagement
       if (user.role === "admin") {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2188,12 +2188,11 @@ function UserManagement({ showError, navigate, BackButton }) {
                                   selectedRole && p.key === "userManagement"
                                 }
                                 onCheckedChange={(checked) => {
-                                  const updated = checked
-                                    ? [...selectedPages, p.key]
-                                    : selectedPages.filter(
-                                        (ap) => ap !== p.key
-                                      );
-                                  setSelectedPages(updated);
+                                  setSelectedPages((prev) =>
+                                    checked
+                                      ? [...prev, p.key]
+                                      : prev.filter((ap) => ap !== p.key)
+                                  );
                                 }}
                               />
                               <Label htmlFor={`perm-${user._id}-${p.key}`}>


### PR DESCRIPTION
## Summary
- handle empty `allowedPages` updates in user permissions
- update permission dialog to use functional state updates

## Testing
- `cd backend && npm test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_b_689d18c6b7dc832f8c8b795eb89b145d