### PR TITLE
fix: allow custom admin permissions

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -816,16 +816,16 @@ app.put(
         if (adminExists)
           return res.status(400).json({ message: "Admin user already exists" });
         user.role = "admin";
-        user.allowedPages = PAGE_NAMES;
+        if (allowedPages !== undefined) {
+          user.allowedPages = allowedPages;
+        } else {
+          user.allowedPages = PAGE_NAMES;
+        }
       } else if (role === "user" && user.role === "admin") {
         user.role = "user";
         if (allowedPages !== undefined) user.allowedPages = allowedPages;
       } else {
         if (allowedPages !== undefined) user.allowedPages = allowedPages;
-      }
-      // ensure admin always has all pages including userManagement
-      if (user.role === "admin") {
-        user.allowedPages = PAGE_NAMES;
       }
       await user.save();
       return res.json({ message: "User updated successfully" });

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1941,7 +1941,7 @@ function UserManagement({ showError, navigate, BackButton }) {
       const res = await fetchWithAuth(`${API_BASE_URL}/api/users/${id}`, {
         method: "PUT",
         body: JSON.stringify({
-          allowedPages: isAdmin ? PAGE_OPTIONS.map((p) => p.key) : pages,
+          allowedPages: pages,
           role: isAdmin ? "admin" : "user",
         }),
       });
@@ -1953,9 +1953,7 @@ function UserManagement({ showError, navigate, BackButton }) {
             u._id === id
               ? {
                   ...u,
-                  allowedPages: isAdmin
-                    ? PAGE_OPTIONS.map((p) => p.key)
-                    : pages,
+                  allowedPages: pages,
                   role: isAdmin ? "admin" : "user",
                 }
               : u


### PR DESCRIPTION
## Summary
- allow updating admin allowedPages without automatic reset
- send selected permission list from UI for admins

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_b_689d1b97abf0832f8dfa3067e26e08d0