### PR TITLE
Fix contract edit form initialization

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -541,7 +541,9 @@ export default function App() {
 
     useEffect(() => {
       if (editingContract) {
-        setContract(editingContract);
+        // Merge fetched contract data with existing defaults so that
+        // undefined fields from the server don't clear the form state.
+        setContract((prev) => ({ ...prev, ...editingContract }));
       }
     }, [editingContract]);
 


### PR DESCRIPTION
## Summary
- ensure contract edit form merges fetched data with defaults to prevent blank fields

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_689df6dab228832f865511bb777d01e6