### PR TITLE
Move contract creation menu options to end

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -130,14 +130,14 @@ const PAGE_NAMES = [
   "hallReporting",
   "studioReporting",
   "userManagement",
-  "createContract",
-  "studioContract",
   // Pages related to contract listings were previously missing which
   // caused selected permissions to be discarded on save. Including them
   // ensures allowedPages for admin users cover every page exposed on the
   // frontend.
   "hallContracts",
   "studioContracts",
+  "createContract",
+  "studioContract",
 ];
 
 const userSchema = new mongoose.Schema(

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -72,10 +72,10 @@ const PAGE_OPTIONS = [
   { key: "hallReporting", label: "گزارش‌گیری قراردادهای سالن عقد" },
   { key: "studioReporting", label: "گزارش‌گیری قراردادهای استدیو جم" },
   { key: "userManagement", label: "مدیریت کاربران" },
-  { key: "createContract", label: "ثبت قرارداد سالن عقد" },
-  { key: "studioContract", label: "ثبت قرارداد استدیو جم" },
   { key: "hallContracts", label: "قراردادهای سالن عقد" },
   { key: "studioContracts", label: "قراردادهای استدیو جم" },
+  { key: "createContract", label: "ثبت قرارداد سالن عقد" },
+  { key: "studioContract", label: "ثبت قرارداد استدیو جم" },
 ];
 
 // ------------------------------------------------------------------

--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -110,6 +110,19 @@ const Dashboard = ({ fetchAllData, handleLogout, navigate }) => {
             <Users className="h-4 w-4 mr-2" /> مدیریت کاربران
           </Button>
         )}
+        {allowedPages.includes("hallContracts") && (
+          <Button onClick={() => navigate("hallContracts")} variant="secondary">
+            <FileText className="h-4 w-4 mr-2" /> لیست قرارداد های سالن عقد
+          </Button>
+        )}
+        {allowedPages.includes("studioContracts") && (
+          <Button
+            onClick={() => navigate("studioContracts")}
+            variant="secondary"
+          >
+            <FileText className="h-4 w-4 mr-2" /> لیست قرارداد های استدیو جم
+          </Button>
+        )}
         {allowedPages.includes("createContract") && (
           <Button
             onClick={() => {
@@ -122,19 +135,6 @@ const Dashboard = ({ fetchAllData, handleLogout, navigate }) => {
         {allowedPages.includes("studioContract") && (
           <Button onClick={() => navigate("studioContract")}>
             <FileText className="h-4 w-4 mr-2" /> ثبت قرارداد استدیو جم
-          </Button>
-        )}
-        {allowedPages.includes("hallContracts") && (
-          <Button onClick={() => navigate("hallContracts")} variant="secondary">
-            <FileText className="h-4 w-4 mr-2" /> لیست قرارداد های سالن عقد
-          </Button>
-        )}
-        {allowedPages.includes("studioContracts") && (
-          <Button
-            onClick={() => navigate("studioContracts")}
-            variant="secondary"
-          >
-            <FileText className="h-4 w-4 mr-2" /> لیست قرارداد های استدیو جم
           </Button>
         )}
       </div>


### PR DESCRIPTION
## Summary
- reorder global page options so contract creation routes appear last
- update dashboard menu to render contract creation buttons at the end
- align backend page name list with new menu order

## Testing
- `cd backend && npm test`
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689e478f82ec832f8e2f41dfa24a40b5