### PR TITLE
feat: add activity log tracking and viewer

### DIFF
--- a/frontend/src/ActivityLogs.jsx
+++ b/frontend/src/ActivityLogs.jsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useState } from "react";
+import { fetchWithAuth, API_BASE_URL } from "./store";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+export default function ActivityLogs() {
+  const [logs, setLogs] = useState([]);
+
+  useEffect(() => {
+    const loadLogs = async () => {
+      try {
+        const res = await fetchWithAuth(`${API_BASE_URL}/api/logs`);
+        if (res.ok) {
+          const data = await res.json();
+          setLogs(data);
+        }
+      } catch (e) {
+        console.error("Failed to fetch logs", e);
+      }
+    };
+    loadLogs();
+  }, []);
+
+  return (
+    <div className="container mx-auto p-4 font-iransans">
+      <h1 className="text-2xl font-bold mb-4">گزارش فعالیت‌ها</h1>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>کاربر</TableHead>
+            <TableHead>عملیات</TableHead>
+            <TableHead>زمان</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {logs.map((log) => (
+            <TableRow key={log._id}>
+              <TableCell>{log.user}</TableCell>
+              <TableCell>{`${log.method} ${log.endpoint}`}</TableCell>
+              <TableCell>
+                {new Date(log.createdAt).toLocaleString("fa-IR")}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,6 +10,7 @@ import StudioContract from "./StudioContract";
 import HallContracts from "./HallContracts";
 import StudioContracts from "./StudioContracts";
 import Dashboard from "./Dashboard";
+import ActivityLogs from "./ActivityLogs";
 
 import {
   useStore,
@@ -76,6 +77,7 @@ const PAGE_OPTIONS = [
   { key: "studioContracts", label: "قراردادهای استدیو جم" },
   { key: "createContract", label: "ثبت قرارداد سالن عقد" },
   { key: "studioContract", label: "ثبت قرارداد استدیو جم" },
+  { key: "activityLogs", label: "گزارش فعالیت‌ها" },
 ];
 
 // ------------------------------------------------------------------
@@ -1909,6 +1911,8 @@ export default function App() {
             BackButton={BackButton}
           />
         );
+      case "activityLogs":
+        return <ActivityLogs />;
       default:
         return (
           <Dashboard

--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -137,6 +137,11 @@ const Dashboard = ({ fetchAllData, handleLogout, navigate }) => {
             <FileText className="h-4 w-4 mr-2" /> ثبت قرارداد استدیو جم
           </Button>
         )}
+        {allowedPages.includes("activityLogs") && (
+          <Button onClick={() => navigate("activityLogs")} variant="secondary">
+            <FileText className="h-4 w-4 mr-2" /> گزارش فعالیت‌ها
+          </Button>
+        )}
       </div>
       {contracts.length > 0 && (
         <div className="mt-8">


### PR DESCRIPTION
## Summary
- log authenticated write actions and logins to a new ActivityLog collection
- expose `/api/logs` and include new `activityLogs` page in navigation
- add React page to list recent activity logs

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_b_689f04e9b07c832f994f75124193e216