### PR TITLE
Limit contract search results to 50

### DIFF
--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -24,7 +24,7 @@ const Dashboard = ({ fetchAllData, handleLogout, navigate }) => {
         // available before merging.
         const [hallRes, studioRes] = await Promise.all([
           fetchWithAuth(
-            `${API_BASE_URL}/api/contracts/search?limit=1000&page=1`
+            `${API_BASE_URL}/api/contracts/search?limit=50&page=1`
           ),
           fetchWithAuth(`${API_BASE_URL}/api/studio-contracts`),
         ]);


### PR DESCRIPTION
## Summary
- limit contract search query in Dashboard to 50 to satisfy API validation

## Testing
- `npm test` (frontend) *(fails: Missing script "test")*
- `npm test` (backend)

------
https://chatgpt.com/codex/tasks/task_b_689f0fbd25d8832fa2c2eca6d1cd621c