### PR TITLE
Increase API rate limit thresholds

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -93,7 +93,7 @@ app.use(activityLogger);
 // Rate limit عمومی
 const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
-  max: 100,
+  max: 1000,
   standardHeaders: true,
   legacyHeaders: false,
 });
@@ -102,7 +102,7 @@ app.use("/api", apiLimiter);
 // Rate limit سخت‌گیرانه‌تر برای ورود
 const loginLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
-  max: 10,
+  max: 100,
   standardHeaders: true,
   legacyHeaders: false,
 });


### PR DESCRIPTION
## Summary
- relax general API rate limit to 1000 requests per 15 minutes
- loosen login rate limit to 100 requests per 15 minutes to reduce premature blocking

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_b_689f1236c12c832f9a83401e767bc821