### PR TITLE
Add back button to activity logs page

### DIFF
--- a/frontend/src/ActivityLogs.jsx
+++ b/frontend/src/ActivityLogs.jsx
@@ -9,7 +9,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 
-export default function ActivityLogs() {
+export default function ActivityLogs({ BackButton }) {
   const [logs, setLogs] = useState([]);
 
   useEffect(() => {
@@ -29,6 +29,7 @@ export default function ActivityLogs() {
 
   return (
     <div className="container mx-auto p-4 font-iransans">
+      {BackButton && <BackButton />}
       <h1 className="text-2xl font-bold mb-4">گزارش فعالیت‌ها</h1>
       <Table>
         <TableHeader>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1914,7 +1914,7 @@ export default function App() {
             />
           );
         case "activityLogs":
-          return <ActivityLogs />;
+          return <ActivityLogs BackButton={BackButton} />;
         case "calendar":
           return <CalendarPage />;
         default:


### PR DESCRIPTION
## Summary
- allow Activity Logs page to render a BackButton for returning to previous view
- pass BackButton component when routing to activityLogs

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_b_689f132b45fc832fb4620bb2fb8a5694