### PR TITLE
Add back button to calendar page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1916,7 +1916,7 @@ export default function App() {
         case "activityLogs":
           return <ActivityLogs BackButton={BackButton} />;
         case "calendar":
-          return <CalendarPage />;
+          return <CalendarPage BackButton={BackButton} />;
         default:
           return (
             <Dashboard

--- a/frontend/src/CalendarPage.tsx
+++ b/frontend/src/CalendarPage.tsx
@@ -353,7 +353,7 @@ function EventModal({
   );
 }
 
-export default function CalendarApp() {
+export default function CalendarApp({ BackButton }: { BackButton?: React.ComponentType }) {
   const { events, add, remove, clearAll } = useEventStore();
   const [current, setCurrent] = useState(() => dayjs().startOf("month")); // ماه فعلی (جلالی)
   const [modalOpen, setModalOpen] = useState(false);
@@ -437,6 +437,7 @@ export default function CalendarApp() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-indigo-50 via-white to-rose-50" dir="rtl">
       <div className="max-w-7xl mx-auto px-4 py-6">
+        {BackButton && <BackButton />}
         {/* هدر */}
         <header className="flex flex-col md:flex-row items-start md:items-center justify-between gap-4 mb-6">
           <div>


### PR DESCRIPTION
## Summary
- add optional BackButton prop to CalendarPage
- pass BackButton from App to CalendarPage

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689f1f8669b4832f8a45d02952ec2971