### PR TITLE
Fix edit contract form not pre-filled

### DIFF
--- a/frontend/src/ContractsList.jsx
+++ b/frontend/src/ContractsList.jsx
@@ -114,15 +114,13 @@ const ContractsList = ({
     }
   };
 
-  const handleEdit = async (id) => {
-    const res = await fetchWithAuth(`${API_BASE_URL}/api/contracts/${id}`);
-    if (res.ok) {
-      const data = await res.json();
-      setEditingContract(normalizeContractTimes([data])[0]);
+  const handleEdit = (id) => {
+    const selected = contracts.find((c) => c._id === id);
+    if (selected) {
+      setEditingContract(selected);
       navigate("createContract");
     } else {
-      const t = await res.text();
-      showError(t || "خطا در دریافت اطلاعات قرارداد.");
+      showError("خطا در دریافت اطلاعات قرارداد.");
     }
   };
 


### PR DESCRIPTION
## Summary
- use already-loaded contract data when editing to ensure form fields are pre-filled

## Testing
- `cd backend && npm test`
- `cd frontend && npm test` *(fails: Missing script "test" )*

------
https://chatgpt.com/codex/tasks/task_b_689f21aa6e84832f9086ab30943ce289